### PR TITLE
fix(cli): log error if no messages are found

### DIFF
--- a/libs/cli/src/cmds/extract.ts
+++ b/libs/cli/src/cmds/extract.ts
@@ -131,5 +131,8 @@ function makeTranslationsFile(
     const translationFile = serializer.renderFile(extractor.messages, locale);
     FileUtils.writeFile(fileOutput, translationFile);
     console.log(`  Generated file "${fileOutput}"`);
+  } else {
+    console.error(`No messages found. You should build the angular app without a language target for this command to work.`)
+    process.exit(1)
   }
 }


### PR DESCRIPTION
If no messages are found in the source folder the command should error instead of exiting silently